### PR TITLE
Upgrade target framework from .NET 6 to .NET 8

### DIFF
--- a/Base/Xrpl.AddressCodec/Xrpl.AddressCodec.csproj
+++ b/Base/Xrpl.AddressCodec/Xrpl.AddressCodec.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <LangVersion>9.0</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Xrpl</RootNamespace>
     <PackOnBuild>true</PackOnBuild>
     <Authors>Chris Will, Denis Angell</Authors>
@@ -18,7 +18,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\net6.0\XrplCSharp.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8.0\XrplCSharp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Base/Xrpl.BinaryCodec/Xrpl.BinaryCodec.csproj
+++ b/Base/Xrpl.BinaryCodec/Xrpl.BinaryCodec.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <LangVersion>9.0</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Xrpl</RootNamespace>
     <PackOnBuild>true</PackOnBuild>
     <Authors>Chris Will, Denis Angell</Authors>
@@ -18,7 +18,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\net6.0\XrplCSharp.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8.0\XrplCSharp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Base/Xrpl.Keypairs/Xrpl.Keypairs.csproj
+++ b/Base/Xrpl.Keypairs/Xrpl.Keypairs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <LangVersion>9.0</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Xrpl</RootNamespace>
     <PackOnBuild>true</PackOnBuild>
     <Authors>Chris Will, Denis Angell</Authors>
@@ -18,7 +18,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\net6.0\XrplCSharp.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8.0\XrplCSharp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,13 @@
 ### Requirements
 
 We use VisualStudio version 13.4.1 for development - that is the version that our linters require.
-You must also use `dotnet` 6. You can check your `dotnet` version with:
+You must also use `dotnet` 8. You can check your `dotnet` version with:
 
 ```bash
 dotnet --version
 ```
 
-`6.0.400`
+`8.0.400`
 
 ### Set up
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The `XrplCSharp` library is available on [DotNet](https://dotnet.microsoft.com/)
 dotnet add package XrplCSharp --version 1.0.0
 ```
 
-The library supports [Dotnet 6](https://dotnet.microsoft.com/) and later.
+The library supports [Dotnet 8](https://dotnet.microsoft.com/) and later.
 
 <!-- [![Supported Versions](https://img.shields.io/pypi/pyversions/XrplCSharp.svg)](https://pypi.org/project/xrpl-py) -->
 

--- a/Tests/TestsClients/Test.ClonsoleApp/Test.ClonsoleApp.csproj
+++ b/Tests/TestsClients/Test.ClonsoleApp/Test.ClonsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Tests/Xrpl.AddressCodec.Test/Xrpl.AddressCodec.Test.csproj
+++ b/Tests/Xrpl.AddressCodec.Test/Xrpl.AddressCodec.Test.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<!-- <TargetFramework>netstandard2.0</TargetFramework> -->
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>XrplTests</RootNamespace>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Tests/Xrpl.BinaryCodec.Test/Xrpl.BinaryCodec.Test.csproj
+++ b/Tests/Xrpl.BinaryCodec.Test/Xrpl.BinaryCodec.Test.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<!-- <TargetFramework>netstandard2.0</TargetFramework> -->
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>XrplTests</RootNamespace>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Tests/Xrpl.Keypairs.Test/Xrpl.Keypairs.Test.csproj
+++ b/Tests/Xrpl.Keypairs.Test/Xrpl.Keypairs.Test.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<!-- <TargetFramework>netstandard2.0</TargetFramework> -->
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>XrplTests</RootNamespace>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Tests/Xrpl.Tests/Xrpl.Tests.csproj
+++ b/Tests/Xrpl.Tests/Xrpl.Tests.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<!-- <TargetFramework>netstandard2.0</TargetFramework> -->
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>XrplTests</RootNamespace>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Xrpl/Xrpl.csproj
+++ b/Xrpl/Xrpl.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Xrpl</RootNamespace>
     <PackOnBuild>true</PackOnBuild>
     <Authors>Chris Will, Denis Angell</Authors>
@@ -19,7 +19,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\net6.0\XrplCSharp.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8.0\XrplCSharp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades all projects in the solution from `net6.0` to `net8.0` (the current LTS release; `net6.0` reached end-of-support on 2024-11-12).

## Changes

- Set `<TargetFramework>net8.0</TargetFramework>` in all 9 `.csproj` files:
  - `Xrpl/Xrpl.csproj`
  - `Base/Xrpl.AddressCodec/Xrpl.AddressCodec.csproj`
  - `Base/Xrpl.BinaryCodec/Xrpl.BinaryCodec.csproj`
  - `Base/Xrpl.Keypairs/Xrpl.Keypairs.csproj`
  - `Tests/Xrpl.Tests/Xrpl.Tests.csproj`
  - `Tests/Xrpl.AddressCodec.Test/Xrpl.AddressCodec.Test.csproj`
  - `Tests/Xrpl.BinaryCodec.Test/Xrpl.BinaryCodec.Test.csproj`
  - `Tests/Xrpl.Keypairs.Test/Xrpl.Keypairs.Test.csproj`
  - `Tests/TestsClients/Test.ClonsoleApp/Test.ClonsoleApp.csproj`
- Update the `DocumentationFile` output path from `bin\Debug\net6.0\XrplCSharp.xml` to `bin\Debug\net8.0\XrplCSharp.xml` in the three Base library projects and `Xrpl.csproj`.
- Update `README.md` to state the library supports Dotnet 8 and later.
- Update `CONTRIBUTING.md` requirements to reference `dotnet` 8 / `8.0.400`.

The CI workflow (`.github/workflows/dotnet.test.yml`) already pinned `dotnet-version: 8.0.x`, so no workflow changes were needed.

## Testing

- Built the full solution against the .NET 8 SDK in Release configuration: 0 errors (warnings unchanged from before).
- Ran the unit-test suite (`dotnet test --filter "TestU"`): 183/183 passed.

```
Test Run Successful.
Total tests: 183
     Passed: 183
 Total time: 2.1171 Seconds
```

Integration tests (`TestI`) require a live `rippled` Docker service and were not exercised locally; they are run by the existing `integration` job in CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52af105b-98e7-4a04-b498-75778e27e7af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52af105b-98e7-4a04-b498-75778e27e7af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

